### PR TITLE
Cambio en los errores 404

### DIFF
--- a/src/main/java/com/evtnet/evtnetback/Controllers/BaseControllerImpl.java
+++ b/src/main/java/com/evtnet/evtnetback/Controllers/BaseControllerImpl.java
@@ -29,7 +29,7 @@ public abstract class BaseControllerImpl<E extends Base, S extends BaseServiceIm
         }
     }
 
-    @GetMapping("/{id}")
+    @GetMapping("/getOne/{id}")
     public ResponseEntity<?> getOne(@PathVariable Long id){
         try{
             return ResponseEntity.status(HttpStatus.OK).body(servicio.findById(id));
@@ -48,7 +48,7 @@ public abstract class BaseControllerImpl<E extends Base, S extends BaseServiceIm
         }
     }
 
-    @PutMapping("/{id}")
+    @PutMapping("/update/{id}")
     public ResponseEntity<?> update(@PathVariable Long id, @RequestBody E entity){
         try{
             return ResponseEntity.status(HttpStatus.OK).body(servicio.update(id, entity));
@@ -57,7 +57,7 @@ public abstract class BaseControllerImpl<E extends Base, S extends BaseServiceIm
         }
     }
 
-    @DeleteMapping("/{id}")
+    @DeleteMapping("/delete/{id}")
     public ResponseEntity<?> delete(@PathVariable Long id){
         try{
             return ResponseEntity.status(HttpStatus.NO_CONTENT).body(servicio.delete(id));

--- a/src/main/java/com/evtnet/evtnetback/error/GlobalExceptionHandler.java
+++ b/src/main/java/com/evtnet/evtnetback/error/GlobalExceptionHandler.java
@@ -3,6 +3,7 @@ package com.evtnet.evtnetback.error;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.servlet.resource.NoResourceFoundException;
 
 import java.util.Map;
 
@@ -22,6 +23,14 @@ public class GlobalExceptionHandler {
         return ResponseEntity.status(500).body(Map.of(
                 "code", -1,
                 "message", "Error interno del servidor"
+        ));
+    }
+
+    @ExceptionHandler(NoResourceFoundException.class)
+    public ResponseEntity<Map<String,Object>> handleNotFound(NoResourceFoundException ex) {
+        return ResponseEntity.status(404).body(Map.of(
+                "code", 404,
+                "message", "Endpoint no encontrado"
         ));
     }
 }


### PR DESCRIPTION
Ahora tira error 404 en vez de 500 cuando se hace una solicitud a un endpoint que no existe. Esto permite que funcione el proxy del front.